### PR TITLE
Prevent selecting line number

### DIFF
--- a/svjs.css
+++ b/svjs.css
@@ -1,7 +1,7 @@
 table.svjs { font-family: courier; font-size: 0.8em; border-collapse: collapse; border-spacing: 0px; }
 table.svjs td { padding: 0px; }
 
-table.svjs .sequence-pos { color: #999; white-space: nowrap; }
+table.svjs .sequence-pos { color: #999; white-space: nowrap; user-select: none}
 table.svjs .sequence-pos-left { text-align: right; padding-right: 5px; }
 table.svjs .sequence-pos-right { text-align: left; padding-left: 5px; }
 


### PR DESCRIPTION
This change to css means the line number won't be copied over anymore. Requested in https://github.com/ginkgobioworks/edge/issues/20